### PR TITLE
Validate Repository Format in `create_pr` Function

### DIFF
--- a/src/windrak/create_pr.py
+++ b/src/windrak/create_pr.py
@@ -147,8 +147,16 @@ def create_pr(ctx, base, head, repo):
                 return
             click.echo(f"Using repository derived from remote: {repo}")
         
-        owner, repo_name = repo.split('/')
+        try:
+            owner, repo_name = repo.split('/')
+        except ValueError:
+            click.echo("Error: Invalid repository format. Please use 'owner/repo' format.")
+            return
         
+        if not repo or '/' not in repo:
+            click.echo("Error: Invalid repository format. Please use 'owner/repo' format or ensure your git remote is set correctly.")
+            return
+
         # Rest of the function remains the same...
         diff = get_branch_diff(owner, repo_name, base, head, github_token)
         


### PR DESCRIPTION
This pull request adds input validation to the `create_pr` function in `src/windrak/create_pr.py`. It checks if the repository string is in the correct format ('owner/repo') and if it contains a forward slash. If the format is invalid, it displays an error message and exits the function. This change ensures the function is more robust and user-friendly by providing clear error messages for invalid input.